### PR TITLE
adjust pkg name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -264,7 +264,7 @@ with open(os.path.join(thisdir, 'README.md'), encoding='utf-8') as fin:
 
 start_time = time.time()
 
-setup(name='deepspeed',
+setup(name='deepspeed-habana',
       version=version_str,
       description='DeepSpeed library',
       long_description=readme_text,


### PR DESCRIPTION
lets distinguish for user what `deepspeed` he has installed, letter on it will also help to publish these packages for possible integrations