### PR TITLE
enable starcode((kv_head=1)) autotp (#4896)

### DIFF
--- a/deepspeed/module_inject/fusedqkv_utils.py
+++ b/deepspeed/module_inject/fusedqkv_utils.py
@@ -4,7 +4,7 @@
 # DeepSpeed Team
 import torch
 from deepspeed.utils.logging import warning_once
-from deepspeed.module_inject.tp_shard import get_shard_size, get_shard_size_list, get_num_kv_heads
+from deepspeed.module_inject.tp_shard import get_shard_size, get_shard_size_list, get_num_kv_heads, get_n_embd
 import re
 
 
@@ -17,7 +17,7 @@ def split_by_qkvlist_and_refuse(qkv_list, split_size, split_dim=0, cat_dim=0):
 
 
 def require_tp_fused_qkvw(name, mp_size):
-    fused_qkvw_name_list = ['qkv_proj', 'query_key_value', 'attn.Wqkv']
+    fused_qkvw_name_list = ['qkv_proj', 'query_key_value', 'attn.Wqkv', 'self_attn.W_pack', 'c_attn']
 
     if mp_size == 1:
         return False
@@ -36,6 +36,9 @@ def prepare_tp_fused_qkvw(module_str, src, mp_size, gpu_index):
         'GLMBlock': 'glmtype',
         "MPTBlock": 'glmtype',
         "MptBlock": 'glmtype',
+        "BaichuanLayer": 'glmtype',
+        "DecoderLayer": 'glmtype',
+        "GPTBigCodeBlock": 'bigcodetype'
     }
 
     def _codegen_type_transpose(input, mp_size, codegen_mp_num=4):
@@ -72,6 +75,14 @@ def prepare_tp_fused_qkvw(module_str, src, mp_size, gpu_index):
         split_fusedqkv = input.split(get_shard_size_list(shape[0], mp_size), dim=0)
         return split_fusedqkv[gpu_index]
 
+    def _bigcode_type_transpose(input, mp_size):
+        n_embd = get_n_embd()
+        q = input[:n_embd]
+        kv = input[n_embd:]
+        shape = q.shape
+        split_q = q.split(get_shard_size_list(shape[0], mp_size), dim=0)
+        return torch.cat((split_q[gpu_index], kv), dim=0)
+
     def _transpose_fused_qkvw(src, mp_size, fused_qkv_type=None):
 
         # suppose num_heads=n, q(n)_w means the n-th q head linear weight, the weight format are as following
@@ -85,6 +96,8 @@ def prepare_tp_fused_qkvw(module_str, src, mp_size, gpu_index):
             return _codegen_type_transpose(src, mp_size)
         elif fused_qkv_type == 'glmtype':
             return _glm_type_transpose(src, mp_size)
+        elif fused_qkv_type == 'bigcodetype':
+            return _bigcode_type_transpose(src, mp_size)
 
         raise ValueError("unknown fused_qkv_type")
 

--- a/deepspeed/module_inject/replace_module.py
+++ b/deepspeed/module_inject/replace_module.py
@@ -16,7 +16,7 @@ from .replace_policy import replace_policies, generic_policies
 from .auto_tp import AutoTP, ReplaceWithTensorSlicing, Loading
 
 from deepspeed import comm as dist
-from deepspeed.module_inject.tp_shard import set_num_kv_heads
+from deepspeed.module_inject.tp_shard import set_num_kv_heads, set_n_embd
 
 from .load_checkpoint import load_model_with_checkpoint
 import time
@@ -279,6 +279,18 @@ def replace_transformer_layer(orig_layer_impl, model, checkpoint_dict, config, m
 
         # 4. When we have num_kv_heads defined, uneven division is possible, otherwise enforce even division
         set_num_kv_heads(num_kv_heads)
+
+        # 4.1 Get n_embd
+        n_embd = None
+        multi_query_n_embd_names = ['n_embd']
+        for name in multi_query_n_embd_names:
+            if hasattr(model_config, name):
+                n_embd = getattr(model_config, name)
+            if n_embd != None:
+                break
+
+        # 4.2 set n_embd
+        set_n_embd(n_embd)
 
         # 5. Set linear policies
         _autotp.update_linear_policies()

--- a/deepspeed/module_inject/tp_shard.py
+++ b/deepspeed/module_inject/tp_shard.py
@@ -12,6 +12,11 @@ def set_num_kv_heads(num):
     num_kv_heads = num
 
 
+def set_n_embd(num):
+    global n_embd
+    n_embd = num
+
+
 def get_num_kv_heads():
     global num_kv_heads
     return num_kv_heads
@@ -30,6 +35,11 @@ def get_shard_size(total_size, mp_size, rank=None):
             return total_size // mp_size
         else:
             assert False, f"Number of attention heads ({total_size}) must be divisible by mp_size ({mp_size})"
+
+
+def get_n_embd():
+    global n_embd
+    return n_embd
 
 
 def get_shard_size_list(total_size, mp_size):


### PR DESCRIPTION
I took the PR from the microsoft/DeepSpeed repository to enable `bigcode/starcoderbase-3b` model. 

https://github.com/microsoft/DeepSpeed/pull/4896

https://huggingface.co/bigcode/starcoderbase-3b

It fixes the problem below:

```bash
Traceback (most recent call last):
  File "/home/optimum-habana/examples/text-generation/run_generation.py", line 572, in <module>
    main()
  File "/home/optimum-habana/examples/text-generation/run_generation.py", line 263, in main
    model, tokenizer, generation_config = initialize_model(args, logger)
  File "/home/optimum-habana/examples/text-generation/utils.py", line 379, in initialize_model
    else setup_distributed_model(args, model_dtype, model_kwargs, logger)
  File "/home/optimum-habana/examples/text-generation/utils.py", line 235, in setup_distributed_model
    model = deepspeed.init_inference(model, **ds_inference_kwargs)
  File "/usr/local/lib/python3.10/dist-packages/deepspeed/__init__.py", line 343, in init_inference
    engine = InferenceEngine(model, config=ds_inference_config)
  File "/usr/local/lib/python3.10/dist-packages/deepspeed/inference/engine.py", line 168, in __init__
    self._apply_injection_policy(config, client_module)
  File "/usr/local/lib/python3.10/dist-packages/deepspeed/inference/engine.py", line 417, in _apply_injection_policy
    replace_transformer_layer(client_module, self.module, checkpoint, config, self.config)
  File "/usr/local/lib/python3.10/dist-packages/deepspeed/module_inject/replace_module.py", line 342, in replace_transformer_layer
    replaced_module = replace_module(model=model,
  File "/usr/local/lib/python3.10/dist-packages/deepspeed/module_inject/replace_module.py", line 592, in replace_module
    replaced_module, _ = _replace_module(model, policy, state_dict=sd)
  File "/usr/local/lib/python3.10/dist-packages/deepspeed/module_inject/replace_module.py", line 652, in _replace_module
    _, layer_id = _replace_module(child,
  File "/usr/local/lib/python3.10/dist-packages/deepspeed/module_inject/replace_module.py", line 652, in _replace_module
    _, layer_id = _replace_module(child,
  File "/usr/local/lib/python3.10/dist-packages/deepspeed/module_inject/replace_module.py", line 628, in _replace_module
    replaced_module = policies[child.__class__][0](child,
  File "/usr/local/lib/python3.10/dist-packages/deepspeed/module_inject/replace_module.py", line 306, in replace_fn
    new_module = replace_wo_policy(child, _policy, prefix=prefix, state_dict=state_dict)
  File "/usr/local/lib/python3.10/dist-packages/deepspeed/module_inject/replace_module.py", line 289, in replace_wo_policy
    return _autotp._replace_module(module)
  File "/usr/local/lib/python3.10/dist-packages/deepspeed/module_inject/auto_tp.py", line 459, in _replace_module
    self._replace_module(child, name, class_name)
  File "/usr/local/lib/python3.10/dist-packages/deepspeed/module_inject/auto_tp.py", line 444, in _replace_module
    setattr(r_module, name, self.linear_policies[child.__class__](child, prev_name + '.' + name,
  File "/usr/local/lib/python3.10/dist-packages/deepspeed/module_inject/auto_tp.py", line 363, in _replace
    data = child.weight.data.split(get_shard_size_list(weight_shape[0], self.mp_size),
  File "/usr/local/lib/python3.10/dist-packages/torch/_tensor.py", line 906, in split
    return torch._VF.split_with_sizes(self, split_size, dim)
RuntimeError: split_with_sizes expects split_sizes to sum exactly to 3072 (input tensor's size at dimension 0), but got split_sizes=[418, 418, 418, 418, 418, 418, 279, 279]
```