### PR TITLE
resolve KeyError: 'PDSH_SSH_ARGS_APPEND' (microsoft#5318)

### DIFF
--- a/deepspeed/launcher/multinode_runner.py
+++ b/deepspeed/launcher/multinode_runner.py
@@ -74,7 +74,8 @@ class PDSHRunner(MultiNodeRunner):
     def get_cmd(self, environment, active_resources):
         environment['PDSH_RCMD_TYPE'] = 'ssh'
         if self.args.ssh_port is not None:  # only specify ssh port if it is specified
-            environment["PDSH_SSH_ARGS_APPEND"] += f" -p {self.args.ssh_port}"
+            environment["PDSH_SSH_ARGS_APPEND"] = f"{environment.get('PDSH_SSH_ARGS_APPEND', '')} \
+                -p {self.args.ssh_port}
 
         active_workers = ",".join(active_resources.keys())
         logger.info("Running on the following workers: %s" % active_workers)


### PR DESCRIPTION
when start job with `deepspeed --hostfile hostfile --master_addr $MASTER_IP --ssh_port 20023 src/train_bash.py `

get error: KeyError: 'PDSH_SSH_ARGS_APPEND' in
https://github.com/microsoft/DeepSpeed/blob/master/deepspeed/launcher/multinode_runner.py#L77

because PDSH_SSH_ARGS_APPEND not in environment.


---------